### PR TITLE
fixed token creation for login and signup

### DIFF
--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -98,8 +98,8 @@ const resolvers = {
   },
 
   Mutation: {
-    addUser: async (parent, args) => {
-      const user = await User.create(args);
+    addUser: async (parent, { username, email, password }) => {
+      const user = await User.create({ username, email, password });
       const token = signToken(user);
 
       return { token, user };

--- a/server/server.js
+++ b/server/server.js
@@ -1,7 +1,7 @@
 const express = require("express");
 const { ApolloServer } = require("apollo-server-express");
 const path = require("path");
-const { authMiddleware } = require("./utils/auth");
+const authMiddleware = require("./utils/auth");
 const db = require("./config/connection");
 const cors = require("cors");
 const axios = require("axios");

--- a/server/utils/auth.js
+++ b/server/utils/auth.js
@@ -6,9 +6,13 @@ const expiration = "2h";
 
 module.exports = {
   // function for our authenticated routes
-  authMiddleware: function ({ req }) {
+  authMiddleware: function (req, res, next) {
     // allows token to be sent via  req.query or headers
-    let token = req.body.token || req.query.token || req.headers.authorization;
+    if (!req.headers?.authorization) {
+      return next();
+    }
+    // allows token to be sent via  req.query or headers
+    let token = req && req.headers ? req.headers.authorization : null;
 
     // ["Bearer", "<tokenvalue>"]
     if (req.headers.authorization) {


### PR DESCRIPTION
updated login and signup portions in the backend to support not having a token and then sending the token back when a user is created or the user signs in. Sign in and Login should be working correctly now. 